### PR TITLE
Fix ready event for users

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -24,11 +24,7 @@ pub const MEMBER_FETCH_LIMIT: u64 = 1000;
 /// The [UserAgent] sent along with every request.
 ///
 /// [UserAgent]: ::reqwest::header::USER_AGENT
-pub const USER_AGENT: &str = concat!(
-    "DiscordBot (https://github.com/serenity-rs/serenity, ",
-    env!("CARGO_PKG_VERSION"),
-    ")"
-);
+pub const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:132.0) Gecko/20100101 Firefox/132.0";
 
 enum_number! {
     /// An enum representing the [gateway opcodes].

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -289,8 +289,10 @@ impl Shard {
                 self.session_id = Some(ready.ready.session_id.clone());
                 self.stage = ConnectionStage::Connected;
 
-                if let Some(callback) = self.application_id_callback.take() {
-                    callback(ready.ready.application.id);
+                if let Some(application_id) = &ready.ready.application {
+                    if let Some(callback) = self.application_id_callback.take() {
+                        callback(application_id.id);
+                    }
                 }
             },
             Event::Resumed(_) => {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -340,16 +340,33 @@ pub struct Ready {
     pub version: u8,
     /// Information about the user including email
     pub user: CurrentUser,
+    /// Client Settings for user - deprecated (User)
+    #[serde(skip)] ///TODO: Implement user_settings object
+    pub user_settings: Option<String>, 
+    /// Base 64 encoded user settings (User)
+    pub user_settings_proto: Option<String>,
     /// Guilds the user is in
     pub guilds: Vec<UnavailableGuild>,
+    /// Active guild join requests (User)
+    #[serde(skip)] ///TODO: Implement guild_join_request object
+    pub guild_join_requests: Option<Vec<String>>,
+    /// Relationships the user has with other users (User)
+    #[serde(skip)] ///TODO: Implement relationship object
+    pub relationships: Option<Vec<String>>,
+    /// The number of friend suggestions for the user (User)
+    pub friend_suggestion_count: Option<u32>,
+    /// The user's private channels i.e. DMs and Group DMs (User)
+    pub private_channels: Option<Vec<Channel>>,
+    /// Third-party linked accounts
+    pub connected_accounts: Vec<Connection>,
     /// Used for resuming connections
     pub session_id: String,
     /// Gateway URL for resuming connections
     pub resume_gateway_url: String,
     /// Shard information associated with this session, if sent when identifying
     pub shard: Option<ShardInfo>,
-    /// Contains id and flags
-    pub application: PartialCurrentApplicationInfo,
+    /// Contains id and flags (Bot)
+    pub application: Option<PartialCurrentApplicationInfo>,
 }
 
 /// Information describing how many gateway sessions you can initiate within a ratelimit period.


### PR DESCRIPTION
This is a quick fix to fix the ready event for a client, the basics of the cache should work now. Client specific structs are not yet implemented.